### PR TITLE
CORE-5177 Change from strict affinity type to scope string

### DIFF
--- a/ID.me WebVerify SDK/IDmeWebVerify.h
+++ b/ID.me WebVerify SDK/IDmeWebVerify.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 #define IDME_WEB_VERIFY_VERIFICATION_WAS_CANCELED    @"The user exited the modal navigationController before being verified."
 #define IDME_WEB_VERIFY_ERROR_DOMAIN                 @"ID.me Web Verify Error Domain"
@@ -14,22 +15,6 @@
 @interface IDmeWebVerify : NSObject
 
 typedef void (^IDmeVerifyWebVerifyResults)(NSDictionary *userProfile, NSError *error);
-
-/// This typedef differentiates the different type of affiliation types that can be verified
-typedef NS_ENUM(NSUInteger, IDmeWebVerifyAffiliationType)
-{
-    /// @b Military Verification
-    IDmeWebVerifyAffiliationTypeMilitary = 1,
-    
-    /// @b Student Verification
-    IDmeWebVerifyAffiliationTypeStudent,
-    
-    /// @b Teacher Verification
-    IDmeWebVerifyAffiliationTypeTeacher,
-    
-    /// @b First Respoder Verification
-    IDmeWebVerifyAffiliationTypeResponder
-};
 
 /// This typedef differentiates errors that may occur when authentication a user
 typedef NS_ENUM(NSUInteger, IDmeWebVerifyErrorCode)
@@ -60,7 +45,7 @@ typedef NS_ENUM(NSUInteger, IDmeWebVerifyErrorCode)
 - (void)verifyUserInViewController:(UIViewController *)externalViewController
                       withClientID:(NSString *)clientID
                        redirectURI:(NSString *)redirectURI
-                   affiliationType:(IDmeWebVerifyAffiliationType)affiliationType
+                             scope:(NSString *)scope
                        withResults:(IDmeVerifyWebVerifyResults)webVerificationResults;
 
 @end

--- a/ID.me WebVerify SDK/IDmeWebVerify.h
+++ b/ID.me WebVerify SDK/IDmeWebVerify.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2013 ID.me, Inc. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 #define IDME_WEB_VERIFY_VERIFICATION_WAS_CANCELED    @"The user exited the modal navigationController before being verified."

--- a/ID.me WebVerify SDK/IDmeWebVerify.h
+++ b/ID.me WebVerify SDK/IDmeWebVerify.h
@@ -14,7 +14,7 @@
 
 @interface IDmeWebVerify : NSObject
 
-typedef void (^IDmeVerifyWebVerifyResults)(NSDictionary *userProfile, NSError *error);
+typedef void (^IDmeVerifyWebVerifyResults)(NSDictionary  * _Nullable userProfile, NSError  * _Nullable error);
 
 /// This typedef differentiates errors that may occur when authentication a user
 typedef NS_ENUM(NSUInteger, IDmeWebVerifyErrorCode)
@@ -33,7 +33,7 @@ typedef NS_ENUM(NSUInteger, IDmeWebVerifyErrorCode)
 };
 
 /// THe ID.me WebVerify Singleton method
-+ (IDmeWebVerify *)sharedInstance;
++ (IDmeWebVerify * _Nonnull)sharedInstance;
 
 /**
  @param externalViewController The viewController which will present the modal navigationController
@@ -42,10 +42,10 @@ typedef NS_ENUM(NSUInteger, IDmeWebVerifyErrorCode)
  @param affiliationType The type of group verficiation that should be presented. Check the @c IDmeVerifyAffiliationType typedef for more details
  @param webVerificationResults A block that returns an NSDictionary object and an NSError object. The verified user's profile is stored in an @c NSDictionary object as @c JSON data. If no data was returned, or an error occured, @c NSDictionary is @c nil and @c NSError returns an error code and localized description of the specific error that occured.
  */
-- (void)verifyUserInViewController:(UIViewController *)externalViewController
-                      withClientID:(NSString *)clientID
-                       redirectURI:(NSString *)redirectURI
-                             scope:(NSString *)scope
-                       withResults:(IDmeVerifyWebVerifyResults)webVerificationResults;
+- (void)verifyUserInViewController:(UIViewController * _Nonnull)externalViewController
+                      withClientID:(NSString * _Nonnull)clientID
+                       redirectURI:(NSString * _Nonnull)redirectURI
+                             scope:(NSString * _Nonnull)scope
+                       withResults:(IDmeVerifyWebVerifyResults _Nonnull)webVerificationResults;
 
 @end

--- a/ID.me WebVerify SDK/IDmeWebVerify.m
+++ b/ID.me WebVerify SDK/IDmeWebVerify.m
@@ -22,18 +22,11 @@
 #define kIDmeWebVerifyColorLightBlue                    [UIColor colorWithRed:56.0f/255.0f green:168.0f/255.0f blue:232.0f/255.0f alpha:1.0f]
 #define kIDmeWebVerifyColorDarkBlue                     [UIColor colorWithRed:46.0f/255.0f green:61.0f/255.0f blue:80.0f/255.0f alpha:1.0f]
 
-/// Affiliation Scope Constants
-NSString *const kIDmeWebVerifyScopeMilitary             = @"military";
-NSString *const kIDmeWebVerifyScopeStudent              = @"student";
-NSString *const kIDmeWebVerifyScopeTeacher              = @"teacher";
-NSString *const kIDmeWebVerifyScopeResponder            = @"responder";
-
 @interface IDmeWebVerify () <UIWebViewDelegate>
 @property (nonatomic, copy) IDmeVerifyWebVerifyResults webVerificationResults;
 @property (nonatomic, copy) NSString *clientID;
 @property (nonatomic, copy) NSString *redirectURI;
-@property (nonatomic, copy) NSString *affiliationScope;
-@property (nonatomic, assign) IDmeWebVerifyAffiliationType affiliationType;
+@property (nonatomic, copy) NSString *scope;
 @property (nonatomic, strong) UIViewController *presentingViewController;
 @property (nonatomic, strong) IDmeWebVerifyNavigationController *webNavigationController;
 @property (nonatomic, strong) UIWebView *webView;
@@ -43,8 +36,7 @@ NSString *const kIDmeWebVerifyScopeResponder            = @"responder";
 @implementation IDmeWebVerify
 
 #pragma mark - Initialization Methods
-+ (IDmeWebVerify *)sharedInstance
-{
++ (IDmeWebVerify *)sharedInstance{
     static id sharedInstance = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -53,8 +45,7 @@ NSString *const kIDmeWebVerifyScopeResponder            = @"responder";
     return sharedInstance;
 }
 
-- (id)init
-{
+- (id)init{
     self = [super init];
     if (self) {
         [self clearWebViewCacheAndCookies];
@@ -67,22 +58,19 @@ NSString *const kIDmeWebVerifyScopeResponder            = @"responder";
 - (void)verifyUserInViewController:(UIViewController *)externalViewController
                      withClientID:(NSString *)clientID
                       redirectURI:(NSString *)redirectURI
-                  affiliationType:(IDmeWebVerifyAffiliationType)affiliationType
-                       withResults:(IDmeVerifyWebVerifyResults)webVerificationResults
-{
+                            scope:(NSString *)scope
+                      withResults:(IDmeVerifyWebVerifyResults)webVerificationResults{
     [self clearWebViewCacheAndCookies];
     [self setClientID:clientID];
     [self setRedirectURI:redirectURI];
-    [self setAffiliationType:affiliationType];
-    [self setScopeWithAffiliationType:affiliationType];
+    [self setScope:scope];
     [self setPresentingViewController:externalViewController];
     [self setWebVerificationResults:webVerificationResults];
     [self launchWebNavigationController];
 }
 
 #pragma mark - Authorization Methods (Private)
-- (void)launchWebNavigationController
-{
+- (void)launchWebNavigationController{
     // Initialize _webView
     _webView = [self createWebView];
     
@@ -99,18 +87,17 @@ NSString *const kIDmeWebVerifyScopeResponder            = @"responder";
     }];
 }
 
-- (void)loadWebViewWithAccessTokenRequestPage
-{
-    NSString *requestString = [NSString stringWithFormat:IDME_WEB_VERIFY_GET_AUTH_URI, _clientID, _redirectURI, _affiliationScope];
+- (void)loadWebViewWithAccessTokenRequestPage{
+    NSString *requestString = [NSString stringWithFormat:IDME_WEB_VERIFY_GET_AUTH_URI, _clientID, _redirectURI, _scope];
+
     requestString = [requestString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
     NSURL *requestURL = [NSURL URLWithString:requestString];
     NSURLRequest *request = [NSURLRequest requestWithURL:requestURL];
     [_webView loadRequest:request];
 }
 
-- (void)getUserProfile:(NSString *)accessToken
-{
-    NSString *requestString = [NSString stringWithFormat:IDME_WEB_VERIFY_GET_USER_PROFILE, _affiliationScope, accessToken];
+- (void)getUserProfile:(NSString *)accessToken{
+    NSString *requestString = [NSString stringWithFormat:IDME_WEB_VERIFY_GET_USER_PROFILE, _scope, accessToken];
     
     requestString = [requestString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
     NSURL *requestURL = [NSURL URLWithString:requestString];
@@ -144,8 +131,7 @@ NSString *const kIDmeWebVerifyScopeResponder            = @"responder";
 }
 
 #pragma mark - WebView Persistance Methods (Private)
-- (UIWebView *)createWebView
-{
+- (UIWebView *)createWebView{
     CGRect parentViewControllerViewFrame = [_presentingViewController.view frame];
     CGRect webViewFrame = CGRectMake(0.0f,
                                      0.0f,
@@ -158,8 +144,7 @@ NSString *const kIDmeWebVerifyScopeResponder            = @"responder";
     return webView;
 }
 
-- (void)destroyWebView
-{
+- (void)destroyWebView{
     if (_webView) {
         [_webView loadHTMLString:@"" baseURL:nil];
         [_webView stopLoading];
@@ -169,8 +154,7 @@ NSString *const kIDmeWebVerifyScopeResponder            = @"responder";
     }
 }
 
-- (void)clearWebViewCacheAndCookies
-{
+- (void)clearWebViewCacheAndCookies{
     // Clear Cache
     [[NSURLCache sharedURLCache] removeAllCachedResponses];
     [[NSURLCache sharedURLCache] setDiskCapacity:0];
@@ -185,8 +169,7 @@ NSString *const kIDmeWebVerifyScopeResponder            = @"responder";
     }
 }
 
-- (IDmeWebVerifyNavigationController *)createWebNavigationController
-{
+- (IDmeWebVerifyNavigationController *)createWebNavigationController{
     // Initialize webViewController
     UIViewController *webViewController = [[UIViewController alloc] init];
     [webViewController.view setFrame:[_webView frame]];
@@ -213,8 +196,7 @@ NSString *const kIDmeWebVerifyScopeResponder            = @"responder";
     return navigationController;
 }
 
-- (void)destroyWebNavigationController:(id)sender
-{
+- (void)destroyWebNavigationController:(id)sender{
     if ([sender isMemberOfClass:[UIBarButtonItem class]]) {
         NSDictionary *details = @{ NSLocalizedDescriptionKey : IDME_WEB_VERIFY_VERIFICATION_WAS_CANCELED };
         NSError *error = [[NSError alloc] initWithDomain:IDME_WEB_VERIFY_ERROR_DOMAIN
@@ -231,8 +213,7 @@ NSString *const kIDmeWebVerifyScopeResponder            = @"responder";
 }
 
 #pragma mark - Parsing Methods (Private)
-- (NSMutableDictionary *)parseQueryParametersFromURL:(NSString *)query;
-{
+- (NSMutableDictionary *)parseQueryParametersFromURL:(NSString *)query;{
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
     
     NSArray *components = [query componentsSeparatedByString:@"&"];
@@ -248,8 +229,7 @@ NSString *const kIDmeWebVerifyScopeResponder            = @"responder";
     return parameters;
 }
 
-- (NSDictionary *)testResultsForNull:(NSDictionary *)results
-{
+- (NSDictionary *)testResultsForNull:(NSDictionary *)results{
     NSMutableDictionary *testDictionary = [NSMutableDictionary dictionaryWithDictionary:results];
     NSArray *keys = [testDictionary allKeys];
     for (id key in keys) {
@@ -262,17 +242,16 @@ NSString *const kIDmeWebVerifyScopeResponder            = @"responder";
 }
 
 #pragma mark - UIWebViewDelegate Methods
-- (void)webViewDidStartLoad:(UIWebView *)webView
-{
+- (void)webViewDidStartLoad:(UIWebView *)webView{
     [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
 }
 
-- (void)webViewDidFinishLoad:(UIWebView *)webView
-{
+- (void)webViewDidFinishLoad:(UIWebView *)webView{
     [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
     
     // Get string of current visible webpage
     NSString *query = [[webView.request.mainDocumentURL absoluteString] copy];
+
     if (query) {
         
         /*
@@ -287,6 +266,7 @@ NSString *const kIDmeWebVerifyScopeResponder            = @"responder";
     }
     
     NSDictionary *parameters = [self parseQueryParametersFromURL:query];
+
     if ([parameters objectForKey:IDME_WEB_VERIFY_ACCESS_TOKEN_PARAM]) {
         
         // Extract 'access_token' from URL query parameters that are separated by '&'
@@ -306,45 +286,20 @@ NSString *const kIDmeWebVerifyScopeResponder            = @"responder";
     }
 }
 
-- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
-{
+- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType{
     return YES;
 }
 
-- (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
-{
+- (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error{
     NSLog(@"webView:didFailLoadWithError : %@", error);
 }
 
 #pragma mark - Accessor Methods
-- (NSString *)clientID
-{
+- (NSString *)clientID{
     if ( !_clientID ) {
         NSLog(@"You have not set your 'clientID'! Please set it using the startWithClientID: method.");
     }
     
     return (_clientID) ? _clientID : nil;
 }
-
-- (void)setScopeWithAffiliationType:(IDmeWebVerifyAffiliationType)affiliationType
-{
-    switch (_affiliationType) {
-        case IDmeWebVerifyAffiliationTypeMilitary: {
-            _affiliationScope = kIDmeWebVerifyScopeMilitary;
-        } break;
-            
-        case IDmeWebVerifyAffiliationTypeStudent: {
-            _affiliationScope = kIDmeWebVerifyScopeStudent;
-        } break;
-            
-        case IDmeWebVerifyAffiliationTypeTeacher: {
-            _affiliationScope = kIDmeWebVerifyScopeTeacher;
-        } break;
-            
-        case IDmeWebVerifyAffiliationTypeResponder: {
-            _affiliationScope = kIDmeWebVerifyScopeResponder;
-        } break;
-    }
-}
-
 @end

--- a/ID.me WebVerify SDK/IDmeWebVerify.m
+++ b/ID.me WebVerify SDK/IDmeWebVerify.m
@@ -23,6 +23,7 @@
 #define kIDmeWebVerifyColorDarkBlue                     [UIColor colorWithRed:46.0f/255.0f green:61.0f/255.0f blue:80.0f/255.0f alpha:1.0f]
 
 @interface IDmeWebVerify () <UIWebViewDelegate>
+
 @property (nonatomic, copy) IDmeVerifyWebVerifyResults webVerificationResults;
 @property (nonatomic, copy) NSString *clientID;
 @property (nonatomic, copy) NSString *redirectURI;
@@ -36,12 +37,13 @@
 @implementation IDmeWebVerify
 
 #pragma mark - Initialization Methods
-+ (IDmeWebVerify *)sharedInstance{
++ (IDmeWebVerify *)sharedInstance {
     static id sharedInstance = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         sharedInstance = [self new];
     });
+
     return sharedInstance;
 }
 
@@ -59,7 +61,8 @@
                      withClientID:(NSString *)clientID
                       redirectURI:(NSString *)redirectURI
                             scope:(NSString *)scope
-                      withResults:(IDmeVerifyWebVerifyResults)webVerificationResults{
+                      withResults:(IDmeVerifyWebVerifyResults)webVerificationResults {
+
     [self clearWebViewCacheAndCookies];
     [self setClientID:clientID];
     [self setRedirectURI:redirectURI];
@@ -70,7 +73,8 @@
 }
 
 #pragma mark - Authorization Methods (Private)
-- (void)launchWebNavigationController{
+- (void)launchWebNavigationController {
+
     // Initialize _webView
     _webView = [self createWebView];
     
@@ -85,9 +89,10 @@
         [self loadWebViewWithAccessTokenRequestPage];
         
     }];
+
 }
 
-- (void)loadWebViewWithAccessTokenRequestPage{
+- (void)loadWebViewWithAccessTokenRequestPage {
     NSString *requestString = [NSString stringWithFormat:IDME_WEB_VERIFY_GET_AUTH_URI, _clientID, _redirectURI, _scope];
 
     requestString = [requestString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
@@ -96,7 +101,7 @@
     [_webView loadRequest:request];
 }
 
-- (void)getUserProfile:(NSString *)accessToken{
+- (void)getUserProfile:(NSString * _Nonnull)accessToken {
     NSString *requestString = [NSString stringWithFormat:IDME_WEB_VERIFY_GET_USER_PROFILE, _scope, accessToken];
     
     requestString = [requestString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
@@ -131,7 +136,7 @@
 }
 
 #pragma mark - WebView Persistance Methods (Private)
-- (UIWebView *)createWebView{
+- (UIWebView * _Nonnull)createWebView {
     CGRect parentViewControllerViewFrame = [_presentingViewController.view frame];
     CGRect webViewFrame = CGRectMake(0.0f,
                                      0.0f,
@@ -144,7 +149,8 @@
     return webView;
 }
 
-- (void)destroyWebView{
+- (void)destroyWebView
+{
     if (_webView) {
         [_webView loadHTMLString:@"" baseURL:nil];
         [_webView stopLoading];
@@ -152,9 +158,10 @@
         [_webView removeFromSuperview];
         [self setWebView:nil];
     }
+
 }
 
-- (void)clearWebViewCacheAndCookies{
+- (void)clearWebViewCacheAndCookies {
     // Clear Cache
     [[NSURLCache sharedURLCache] removeAllCachedResponses];
     [[NSURLCache sharedURLCache] setDiskCapacity:0];
@@ -169,7 +176,7 @@
     }
 }
 
-- (IDmeWebVerifyNavigationController *)createWebNavigationController{
+- (IDmeWebVerifyNavigationController * _Nonnull)createWebNavigationController {
     // Initialize webViewController
     UIViewController *webViewController = [[UIViewController alloc] init];
     [webViewController.view setFrame:[_webView frame]];
@@ -213,7 +220,7 @@
 }
 
 #pragma mark - Parsing Methods (Private)
-- (NSMutableDictionary *)parseQueryParametersFromURL:(NSString *)query;{
+- (NSMutableDictionary * _Nonnull)parseQueryParametersFromURL:(NSString * _Nonnull)query;{
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
     
     NSArray *components = [query componentsSeparatedByString:@"&"];
@@ -229,7 +236,7 @@
     return parameters;
 }
 
-- (NSDictionary *)testResultsForNull:(NSDictionary *)results{
+- (NSDictionary * _Nonnull)testResultsForNull:(NSDictionary * _Nonnull)results{
     NSMutableDictionary *testDictionary = [NSMutableDictionary dictionaryWithDictionary:results];
     NSArray *keys = [testDictionary allKeys];
     for (id key in keys) {
@@ -295,7 +302,7 @@
 }
 
 #pragma mark - Accessor Methods
-- (NSString *)clientID{
+- (NSString * _Nullable)clientID{
     if ( !_clientID ) {
         NSLog(@"You have not set your 'clientID'! Please set it using the startWithClientID: method.");
     }

--- a/ID.me WebVerify SDK/IDmeWebVerifyNavigationController.m
+++ b/ID.me WebVerify SDK/IDmeWebVerifyNavigationController.m
@@ -15,8 +15,7 @@
 @implementation IDmeWebVerifyNavigationController
 
 #pragma mark - Orientation Methods
-- (NSUInteger)supportedInterfaceOrientations
-{
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskPortrait;
 }
 

--- a/IDmeWebVerify.podspec
+++ b/IDmeWebVerify.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name         = "IDmeWebVerify"
-  s.version      = "3.1.1"
+  s.version      = "3.1.2"
   s.summary      = "An iOS library that allows you to verify a user's group affiliation status using ID.me's platform."
   s.homepage     = "https://github.com/IDme/ID.me-WebVerify-SDK-iOS"
-  s.platform     = :ios, '7.0'
-  s.source       = { :git => "https://github.com/IDme/ID.me-WebVerify-SDK-iOS.git", :tag => "3.1.1" }
+  s.platform     = :ios, '8.0'
+  s.source       = { :git => "https://github.com/IDme/ID.me-WebVerify-SDK-iOS.git", :tag => s.version.to_s }
   s.source_files = 'ID.me WebVerify SDK/*{.h,.m}'
   s.requires_arc = true
-  s.author       = { "Arthur Ariel Sabintsev" => "arthur@id.me" }
+  s.author       = { "Arthur Ariel Sabintsev" => "arthur@sabintsev.com" }
   s.license      = 'MIT'
 end

--- a/IDmeWebVerify.podspec
+++ b/IDmeWebVerify.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "IDmeWebVerify"
-  s.version      = "3.1.2"
+  s.version      = "3.2.0"
   s.summary      = "An iOS library that allows you to verify a user's group affiliation status using ID.me's platform."
   s.homepage     = "https://github.com/IDme/ID.me-WebVerify-SDK-iOS"
   s.platform     = :ios, '8.0'

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ The ID.me WebVerify SDK for iOS is a library that allows you to verify a user's 
 
 ## Release Information
 
-- **SDK Version:** 3.1.1 (January 22, 2015)
-- **Maintained By:** [Arthur Sabintsev](http://github.com/ArtSabintsev)
+- **SDK Version:** 3.2.0 (June 24, 2016)
+- **Maintained By:** [ID.me](http://github.com/IDme)
 
 For more information please email us at mobile@id.me or visit us at http://developer.id.me.
 
-## Changelog (3.1.1)
-- Minor changes
+## Changelog (3.2.0)
+- Changed parameter from affinityType to scope (NSString)
 
 ## Note
 Once iOS 8 reaches critical mass, we will make use of `NSURLComponents` and `NSURLQueryItems`.
@@ -39,7 +39,7 @@ To launch the modal, the following method must be called in the view controller 
 - (void)verifyUserInViewController:(UIViewController *)externalViewController
                       withClientID:(NSString *)clientID
                        redirectURI:(NSString *)redirectURI
-                   affiliationType:(IDmeWebVerifyAffiliationType)affiliationType
+                             scope:(NSString *)scope
                        withResults:(IDmeVerifyWebVerifyResults)webVerificationResults;
 ```
 
@@ -48,7 +48,7 @@ The params in that method are as follows:
 - `externalViewController`: The viewController which will present the modal navigationController.
 - `clientID`: The clientID provided by ID.me when registering the app at [http://developer.id.me](http://developer.id.me).
 - `redirectURI`: The redirectURI provided to ID.me when registering your app at [http://developer.id.me](http://developer.id.me)
-- `affiliationType`: The type of group verficiation that should be presented. Check the `IDmeVerifyAffiliationType` typedef for more details.
+- `scope`: The handle of your policy ('military', 'student', 'custom_student, etc') as defined for your app at [http://developer.id.me](http://developer.id.me)
 - `webVerificationResults`: A block that returns an NSDictionary object and an NSError object. The verified user's profile is stored in an NSDictionary object as JSON data. If no data was returned, or an error occured, NSDictionary is nil and NSError returns an error code and localized description of the specific error that occured.
 
 In your code, the implementation of this method should yield an expanded form of the `webVerificationResults` block. It is our recommendation that the full implementation of this method look as follows:
@@ -57,7 +57,7 @@ In your code, the implementation of this method should yield an expanded form of
 [[IDmeWebVerify sharedInstance] verifyUserInViewController:<your_presenting_view_controller>
                                               withClientID:<your_clientID>
                                                redirectURI:<your_redirectURI>
-                                           affiliationType:<your_affiliationType>
+                                                      code:<your_scope>
                                                withResults:^(NSDictionary *userProfile, NSError *error) {
                                                 
    											 	if (error) { // Error

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The ID.me WebVerify SDK for iOS is a library that allows you to verify a user's 
 For more information please email us at mobile@id.me or visit us at http://developer.id.me.
 
 ## Changelog (3.2.0)
-- Changed parameter from affinityType to scope (NSString)
+- Changed parameter from affiliationType to scope (NSString)
 
 ## Note
 Once iOS 8 reaches critical mass, we will make use of `NSURLComponents` and `NSURLQueryItems`.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@ For more information please email us at mobile@id.me or visit us at http://devel
 ## Changelog (3.2.0)
 - Changed parameter from affiliationType to scope (NSString)
 
-## Note
-Once iOS 8 reaches critical mass, we will make use of `NSURLComponents` and `NSURLQueryItems`.
-
 ## Download
 
 Get it using CocoaPods

--- a/Sample Project/WebVerifySample.xcodeproj/project.pbxproj
+++ b/Sample Project/WebVerifySample.xcodeproj/project.pbxproj
@@ -165,7 +165,7 @@
 		8E3FE20518B3C729002533DF /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = "ID.me, Inc.";
 			};
 			buildConfigurationList = 8E3FE20818B3C729002533DF /* Build configuration list for PBXProject "WebVerifySample" */;
@@ -251,6 +251,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -307,13 +308,15 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "Brand Assets";
+				CODE_SIGN_IDENTITY = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "WebVerifySample/WebVerifySample-Prefix.pch";
 				INFOPLIST_FILE = "WebVerifySample/WebVerifySample-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.id.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "6344153c-1490-4976-a063-9d1e5b1ecd7f";
+				PROVISIONING_PROFILE = "";
+				TARGETED_DEVICE_FAMILY = 1;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -322,14 +325,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "Brand Assets";
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "WebVerifySample/WebVerifySample-Prefix.pch";
 				INFOPLIST_FILE = "WebVerifySample/WebVerifySample-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.id.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "6344153c-1490-4976-a063-9d1e5b1ecd7f";
+				PROVISIONING_PROFILE = "";
+				TARGETED_DEVICE_FAMILY = 1;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/Sample Project/WebVerifySample/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Sample Project/WebVerifySample/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -7,8 +7,18 @@
     },
     {
       "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "40x40",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
     },
     {
       "idiom" : "iphone",

--- a/Sample Project/WebVerifySample/Images.xcassets/Brand Assets.launchimage/Contents.json
+++ b/Sample Project/WebVerifySample/Images.xcassets/Brand Assets.launchimage/Contents.json
@@ -3,16 +3,14 @@
     {
       "orientation" : "portrait",
       "idiom" : "iphone",
-      "extent" : "full-screen",
       "minimum-system-version" : "7.0",
       "scale" : "2x"
     },
     {
       "orientation" : "portrait",
       "idiom" : "iphone",
-      "subtype" : "retina4",
-      "extent" : "full-screen",
       "minimum-system-version" : "7.0",
+      "subtype" : "retina4",
       "scale" : "2x"
     }
   ],

--- a/Sample Project/WebVerifySample/Images.xcassets/Contents.json
+++ b/Sample Project/WebVerifySample/Images.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Sample Project/WebVerifySample/ViewController.m
+++ b/Sample Project/WebVerifySample/ViewController.m
@@ -18,8 +18,7 @@
 @implementation ViewController
 
 #pragma mark - View Lifecycle
-- (void)viewDidLoad
-{
+- (void)viewDidLoad{
     [super viewDidLoad];
     
     self.view.backgroundColor = [UIColor whiteColor];
@@ -28,8 +27,7 @@
 }
 
 #pragma mark - View Creation
-- (void)setupSubviews
-{
+- (void)setupSubviews{
     // textView
     UITextView *textView = [UITextView new];
     _textView = textView;
@@ -37,7 +35,7 @@
     [textView setFont:[UIFont systemFontOfSize:15.0f]];
     [textView setEditable:NO];
     [self.view addSubview:textView];
-    
+
     // button
     UIButton *button = [UIButton new];
     [button setTranslatesAutoresizingMaskIntoConstraints:NO];
@@ -73,23 +71,24 @@
 }
 
 #pragma mark - Actions
-- (void)verifyAction:(id)sender
-{
+- (void)verifyAction:(id)sender{
     // clear _textView
     [_textView setText:nil];
-    
-    // Show AlertView
-    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:@"Verify Affiliation"
-                                                        message:@"Which affiliation would you like to verify?"
-                                                       delegate:self cancelButtonTitle:@"Cancel"
-                                              otherButtonTitles:@"Military", @"Student", @"Teacher", @"First Responder", nil];
-    [alertView setDelegate:self];
-    [alertView setTag:1000];
-    [alertView show];
+
+    NSString *clientID    = @"<you_client_id>";
+    NSString *scope       = @"<your_handle>";
+    NSString *redirectURL = @"<your_url>";
+
+    [[IDmeWebVerify sharedInstance] verifyUserInViewController:self
+                                    withClientID:clientID
+                                    redirectURI:redirectURL
+                                    scope:scope
+                                    withResults:^(NSDictionary *userProfile, NSError *error) {
+                                        [self resultsWithUserProfile:userProfile andError:error];
+                                    }];
 }
 
-- (void)resultsWithUserProfile:(NSDictionary *)userProfile andError:(NSError *)error
-{
+- (void)resultsWithUserProfile:(NSDictionary *)userProfile andError:(NSError *)error{
     if (error) { // Error
         NSLog(@"Verification Error %ld: %@", error.code, error.localizedDescription);
         _textView.text = [NSString stringWithFormat:@"Error code: %ld\n\n%@", error.code, error.localizedDescription];
@@ -98,42 +97,5 @@
         _textView.text = [NSString stringWithFormat:@"%@", userProfile];
     }
 }
-
-#pragma mark - UIAlertViewDelegate Methods
-- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
-{
-    
-    IDmeWebVerifyAffiliationType affiliationType = IDmeWebVerifyAffiliationTypeMilitary;
-    switch (buttonIndex) {
-        case 1: // Military
-            affiliationType = IDmeWebVerifyAffiliationTypeMilitary;
-            break;
-            
-        case 2: // Student
-            affiliationType = IDmeWebVerifyAffiliationTypeStudent;
-            break;
-            
-        case 3: // Student
-            affiliationType = IDmeWebVerifyAffiliationTypeTeacher;
-            break;
-            
-        case 4: // First Responder
-            affiliationType = IDmeWebVerifyAffiliationTypeResponder;
-            break;
-       }
-    
-    if (buttonIndex > 0) {
-        
-        #warning The clientID and redirectURI in the method below should only be used in this sample project. Please obtain your own clientID at http://developer.id.me before shipping your project
-        [[IDmeWebVerify sharedInstance] verifyUserInViewController:self
-                                                      withClientID:@""
-                                                       redirectURI:@""
-                                                   affiliationType:affiliationType
-                                                       withResults:^(NSDictionary *userProfile, NSError *error) {
-                                                           [self resultsWithUserProfile:userProfile andError:error];
-                                                       }];
-    }
-}
-
 
 @end

--- a/Sample Project/WebVerifySample/ViewController.m
+++ b/Sample Project/WebVerifySample/ViewController.m
@@ -10,24 +10,23 @@
 #import "IDmeWebVerify.h"
 
 @interface ViewController ()
-
 @property (nonatomic, strong) UITextView *textView;
-
 @end
 
 @implementation ViewController
 
 #pragma mark - View Lifecycle
-- (void)viewDidLoad{
+- (void)viewDidLoad {
     [super viewDidLoad];
-    
-    self.view.backgroundColor = [UIColor whiteColor];
-    
     [self setupSubviews];
 }
 
 #pragma mark - View Creation
-- (void)setupSubviews{
+- (void)setupSubviews {
+
+    // view
+    self.view.backgroundColor = [UIColor whiteColor];
+
     // textView
     UITextView *textView = [UITextView new];
     _textView = textView;
@@ -44,16 +43,15 @@
     [button addTarget:self action:@selector(verifyAction:) forControlEvents:UIControlEventTouchUpInside];
     [button.layer setCornerRadius:5.0f];
     [self.view addSubview:button];
-    
+
+    // constraints
     NSNumber *horizontalButtonPadding = @80;
     NSNumber *verticalButtonSeparator = @20;
     NSNumber *buttonHeight = @44;
     NSNumber *textViewHeight = @250;
     NSDictionary *metrics = NSDictionaryOfVariableBindings(horizontalButtonPadding, verticalButtonSeparator, buttonHeight, textViewHeight);
     NSDictionary *views = NSDictionaryOfVariableBindings(textView, button);
-    
-    
-    // constraints
+
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-horizontalButtonPadding-[button]-horizontalButtonPadding-|"
                                                                       options:NSLayoutFormatAlignAllBaseline
                                                                       metrics:metrics
@@ -71,7 +69,8 @@
 }
 
 #pragma mark - Actions
-- (void)verifyAction:(id)sender{
+- (void)verifyAction:(id)sender {
+
     // clear _textView
     [_textView setText:nil];
 
@@ -88,7 +87,8 @@
                                     }];
 }
 
-- (void)resultsWithUserProfile:(NSDictionary *)userProfile andError:(NSError *)error{
+- (void)resultsWithUserProfile:(NSDictionary *)userProfile andError:(NSError *)error {
+    
     if (error) { // Error
         NSLog(@"Verification Error %ld: %@", error.code, error.localizedDescription);
         _textView.text = [NSString stringWithFormat:@"Error code: %ld\n\n%@", error.code, error.localizedDescription];

--- a/Sample Project/WebVerifySample/WebVerifySample-Info.plist
+++ b/Sample Project/WebVerifySample/WebVerifySample-Info.plist
@@ -8,8 +8,12 @@
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIcons</key>
+	<dict/>
+	<key>CFBundleIcons~ipad</key>
+	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>me.id.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
A scope can be any string defined by the handle of a consumer's policy.  The public parameter was changed to allow any NSString rather than a strict type.
