### PR TITLE
CORE-5499: Update iOS SDK to allow access_token return

### DIFF
--- a/ID.me WebVerify SDK/IDmeWebVerify.h
+++ b/ID.me WebVerify SDK/IDmeWebVerify.h
@@ -52,7 +52,7 @@ typedef NS_ENUM(NSUInteger, IDmeWebVerifyErrorCode)
  @param clientID The clientID provided by ID.me when registering the app at @b http://developer.id.me
  @param redierectURI The redirectURI provided to ID.me when registering your app at @b http://developer.id.me
  @param affiliationType The type of group verficiation that should be presented. Check the @c IDmeVerifyAffiliationType typedef for more details
- @param webVerificationResults A block that returns an NSString object or an NSError object.
+ @param webVerificationResults A block that returns an NSString object representing a valid access token or an NSError object.
  */
 
 - (void)verifyUserInViewController:(UIViewController * _Nonnull)externalViewController

--- a/ID.me WebVerify SDK/IDmeWebVerify.h
+++ b/ID.me WebVerify SDK/IDmeWebVerify.h
@@ -13,7 +13,7 @@
 
 @interface IDmeWebVerify : NSObject
 
-typedef void (^IDmeVerifyWebVerifyResults)(NSDictionary  * _Nullable userProfile, NSError  * _Nullable error);
+typedef void (^IDmeVerifyWebVerifyResults)(NSDictionary  * _Nullable userProfile, NSError  * _Nullable error, NSString *  _Nullable accessToken);
 
 /// This typedef differentiates errors that may occur when authentication a user
 typedef NS_ENUM(NSUInteger, IDmeWebVerifyErrorCode)
@@ -46,5 +46,19 @@ typedef NS_ENUM(NSUInteger, IDmeWebVerifyErrorCode)
                        redirectURI:(NSString * _Nonnull)redirectURI
                              scope:(NSString * _Nonnull)scope
                        withResults:(IDmeVerifyWebVerifyResults _Nonnull)webVerificationResults;
+
+/**
+ @param externalViewController The viewController which will present the modal navigationController
+ @param clientID The clientID provided by ID.me when registering the app at @b http://developer.id.me
+ @param redierectURI The redirectURI provided to ID.me when registering your app at @b http://developer.id.me
+ @param affiliationType The type of group verficiation that should be presented. Check the @c IDmeVerifyAffiliationType typedef for more details
+ @param webVerificationResults A block that returns an NSString object or an NSError object.
+ */
+
+- (void)verifyUserInViewController:(UIViewController * _Nonnull)externalViewController
+                      withClientID:(NSString * _Nonnull)clientID
+                       redirectURI:(NSString * _Nonnull)redirectURI
+                             scope:(NSString * _Nonnull)scope
+                   withTokenResult:(IDmeVerifyWebVerifyResults _Nonnull)webVerificationResults;
 
 @end

--- a/ID.me WebVerify SDK/IDmeWebVerify.m
+++ b/ID.me WebVerify SDK/IDmeWebVerify.m
@@ -31,6 +31,7 @@
 @property (nonatomic, strong) UIViewController *presentingViewController;
 @property (nonatomic, strong) IDmeWebVerifyNavigationController *webNavigationController;
 @property (nonatomic, strong) UIWebView *webView;
+@property Boolean loadUser;
 
 @end
 
@@ -56,13 +57,42 @@
     return self;
 }
 
-#pragma mark - Authorization Methods (Public)
 - (void)verifyUserInViewController:(UIViewController *)externalViewController
                      withClientID:(NSString *)clientID
                       redirectURI:(NSString *)redirectURI
                             scope:(NSString *)scope
                       withResults:(IDmeVerifyWebVerifyResults)webVerificationResults {
+     [self verifyUserInViewController: externalViewController
+                         withClientID: clientID
+                          redirectURI: redirectURI
+                                scope: scope
+                             loadUser: YES
+                           withResult: webVerificationResults];
+}
 
+#pragma mark - Authorization Methods (Public)
+- (void)verifyUserInViewController:(UIViewController *)externalViewController
+                      withClientID:(NSString *)clientID
+                       redirectURI:(NSString *)redirectURI
+                             scope:(NSString *)scope
+                   withTokenResult:(IDmeVerifyWebVerifyResults)webVerificationResults {
+    [self verifyUserInViewController: externalViewController
+                        withClientID: clientID
+                         redirectURI: redirectURI
+                               scope: scope
+                            loadUser: NO
+                          withResult: webVerificationResults];
+}
+
+
+#pragma mark - Authorization Methods (Private)
+- (void)verifyUserInViewController:(UIViewController *)externalViewController
+                      withClientID:(NSString *)clientID
+                       redirectURI:(NSString *)redirectURI
+                             scope:(NSString *)scope
+                          loadUser:(Boolean)loadUser
+                         withResult:(IDmeVerifyWebVerifyResults)webVerificationResults {
+    _loadUser = loadUser;
     [self clearWebViewCacheAndCookies];
     [self setClientID:clientID];
     [self setRedirectURI:redirectURI];
@@ -72,7 +102,7 @@
     [self launchWebNavigationController];
 }
 
-#pragma mark - Authorization Methods (Private)
+
 - (void)launchWebNavigationController {
 
     // Initialize _webView
@@ -118,13 +148,13 @@
                 NSDictionary *results = (NSDictionary *)[NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:nil];
                 NSDictionary *userProfile = [self testResultsForNull:results];
                 if (statusCode == 200) {
-                    _webVerificationResults(userProfile, nil);
+                    _webVerificationResults(userProfile, nil, nil);
                 }
             } else {
                 NSError *modifiedError = [[NSError alloc] initWithDomain:IDME_WEB_VERIFY_ERROR_DOMAIN
                                                                     code:IDmeWebVerifyErrorCodeVerificationDidFailToFetchUserProfile
                                                                 userInfo:error.userInfo];
-                _webVerificationResults(nil, modifiedError);
+                _webVerificationResults(nil, modifiedError, nil);
             }
             
             // Dismiss _webViewController and clear _webView cache
@@ -209,7 +239,7 @@
         NSError *error = [[NSError alloc] initWithDomain:IDME_WEB_VERIFY_ERROR_DOMAIN
                                                     code:IDmeWebVerifyErrorCodeVerificationWasCanceledByUser
                                                 userInfo:details];
-        _webVerificationResults(nil, error);
+        _webVerificationResults(nil, error, nil);
     }
     
     [_webNavigationController dismissViewControllerAnimated:YES completion:^{
@@ -278,7 +308,13 @@
         
         // Extract 'access_token' from URL query parameters that are separated by '&'
         NSString *accessToken = [parameters objectForKey:IDME_WEB_VERIFY_ACCESS_TOKEN_PARAM];
-        [self getUserProfile:accessToken];
+
+        if (_loadUser == YES)
+            [self getUserProfile:accessToken];
+        else {
+            _webVerificationResults(nil, nil, accessToken);
+            [self destroyWebNavigationController:self];
+        }
         
     } else if ([parameters objectForKey:IDME_WEB_VERIFY_ERROR_DESCRIPTION_PARAM]) {
         
@@ -287,7 +323,7 @@
         errorDescription = [errorDescription stringByReplacingOccurrencesOfString:@"+" withString:@" "];
         NSDictionary *details = @{ NSLocalizedDescriptionKey : errorDescription };
         NSError *error = [[NSError alloc] initWithDomain:IDME_WEB_VERIFY_ERROR_DOMAIN code:IDmeWebVerifyErrorCodeVerificationWasDeniedByUser userInfo:details];
-        _webVerificationResults(nil, error);
+        _webVerificationResults(nil, error, nil);
         [self destroyWebNavigationController:self];
         
     }

--- a/ID.me WebVerify SDK/IDmeWebVerify.m
+++ b/ID.me WebVerify SDK/IDmeWebVerify.m
@@ -57,6 +57,7 @@
     return self;
 }
 
+#pragma mark - Authorization Methods (Public)
 - (void)verifyUserInViewController:(UIViewController *)externalViewController
                      withClientID:(NSString *)clientID
                       redirectURI:(NSString *)redirectURI
@@ -70,7 +71,6 @@
                            withResult: webVerificationResults];
 }
 
-#pragma mark - Authorization Methods (Public)
 - (void)verifyUserInViewController:(UIViewController *)externalViewController
                       withClientID:(NSString *)clientID
                        redirectURI:(NSString *)redirectURI
@@ -83,7 +83,6 @@
                             loadUser: NO
                           withResult: webVerificationResults];
 }
-
 
 #pragma mark - Authorization Methods (Private)
 - (void)verifyUserInViewController:(UIViewController *)externalViewController
@@ -101,7 +100,6 @@
     [self setWebVerificationResults:webVerificationResults];
     [self launchWebNavigationController];
 }
-
 
 - (void)launchWebNavigationController {
 

--- a/IDmeWebVerify.podspec
+++ b/IDmeWebVerify.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "IDmeWebVerify"
-  s.version      = "3.2.0"
+  s.version      = "3.2.1"
   s.summary      = "An iOS library that allows you to verify a user's group affiliation status using ID.me's platform."
   s.homepage     = "https://github.com/IDme/ID.me-WebVerify-SDK-iOS"
   s.platform     = :ios, '8.0'

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ or download it on Github.
 ## Execution
 Verification occurs through a modal view controller. The modal view controller is a navigation controller initialized with a web-view. The entire OAuth flow occurs through the web-view. Upon successful completion, the modal will automatically be dismissed, and a JSON object in the form of an NSDictionary object containing your user's verificaiton information will be returned to you.
 
-To launch the modal, the following method must be called in the view controller class that will be presenting the modal:
+To launch the modal, the following method can be called in the view controller class that will be presenting the modal:
 
 ```
 - (void)verifyUserInViewController:(UIViewController *)externalViewController
@@ -55,27 +55,57 @@ In your code, the implementation of this method should yield an expanded form of
                                               withClientID:<your_clientID>
                                                redirectURI:<your_redirectURI>
                                                       code:<your_scope>
-                                               withResults:^(NSDictionary *userProfile, NSError *error) {
-                                                
-   											 	if (error) { // Error
-        
-        
-    											} else { // Verification was successful
-    											
+                                               withResults:^(NSDictionary *userProfile, NSError *error, NSString *token) {
+
+   											 	if (error) {
+                                                  // Error
+    											} else {
+    											  // Verification was successful and value will exist for userProfile
     											}
-    											
+
+                                            }];
+
+```
+
+Alternatively, in your code, you can request just the access token using
+
+```
+- (void)verifyUserInViewController:(UIViewController *)externalViewController
+                      withClientID:(NSString *)clientID
+                       redirectURI:(NSString *)redirectURI
+                             scope:(NSString *)scope
+                   withTokenResult:(IDmeVerifyWebVerifyResults)webVerificationResults;
+```
+
+
+
+```
+[[IDmeWebVerify sharedInstance] verifyUserInViewController:<your_presenting_view_controller>
+                                              withClientID:<your_clientID>
+                                               redirectURI:<your_redirectURI>
+                                                      code:<your_scope>
+                                           withTokenResult:^(NSDictionary *userProfile, NSError *error, NSString *token) {
+
+   											 	if (error) {
+                                                  // Error
+    											} else {
+    											  // Verification was successful and value will exist for token
+    											}
+
                                             }];
 
 ```
 
 ## Results
-Each successful request returns the following information:
+Each successful request for user profile returns the following information:
 
 - Group Affiliation (Military Veteran, Student, Firefighter, etc.)
 - Unique user Identifier
 - Verification Status
 
 **NOTE:** Other attributes (e.g., email, first name, last name, etc…) can be returned in the JSON results upon special request. Please email [mobile@id.me](mobile@id.me) if your app needs to gain access to more attributes. 
+
+Successful calls for the access token will return a valid token string.
 
 All potential errors that could occur are explained in the next section.
 

--- a/Sample Project/WebVerifySample/ViewController.m
+++ b/Sample Project/WebVerifySample/ViewController.m
@@ -82,9 +82,26 @@
                                     withClientID:clientID
                                     redirectURI:redirectURL
                                     scope:scope
-                                    withResults:^(NSDictionary *userProfile, NSError *error) {
+                                    withResults:^(NSDictionary *userProfile, NSError *error, NSString *accessToken) {
                                         [self resultsWithUserProfile:userProfile andError:error];
                                     }];
+/*
+ OR
+    [[IDmeWebVerify sharedInstance] verifyUserInViewController:self
+                                                  withClientID:clientID
+                                                   redirectURI:redirectURL
+                                                         scope:scope
+                                                   withTokenResult:^(NSDictionary *userProfile, NSError *error, NSString *accessToken) {
+ if (error) { // Error
+ NSLog(@"Verification Error %ld: %@", error.code, error.localizedDescription);
+ _textView.text = [NSString stringWithFormat:@"Error code: %ld\n\n%@", error.code, error.localizedDescription];
+ } else { // Verification was successful
+ NSLog(@"\nVerification Token:\n %@", accessToken);
+ _textView.text = [NSString stringWithFormat:@"%@", accessToken];
+ }
+                                                   }];
+ */
+
 }
 
 - (void)resultsWithUserProfile:(NSDictionary *)userProfile andError:(NSError *)error {


### PR DESCRIPTION
Allow for option where access_token is returned and no call is made to retrieve user properties.
