### PR TITLE
MOB-442: Remove code that replaces null values with “Unknown”

### DIFF
--- a/ID.me WebVerify SDK/IDmeWebVerify.m
+++ b/ID.me WebVerify SDK/IDmeWebVerify.m
@@ -339,17 +339,6 @@
     return parameters;
 }
 
-- (NSDictionary * _Nonnull)testResultsForNull:(NSDictionary * _Nonnull)results{
-    NSMutableDictionary *testDictionary = [NSMutableDictionary dictionaryWithDictionary:results];
-    NSArray *keys = [testDictionary allKeys];
-    for (id key in keys) {
-        if ([testDictionary valueForKey:key] == [NSNull null]) {
-            [testDictionary setValue:@"Unknown" forKey:key];
-        }
-    }
-    
-    return [NSDictionary dictionaryWithDictionary:testDictionary];
-}
 
 #pragma mark - UIWebViewDelegate Methods
 -(void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation{

--- a/ID.me WebVerify SDK/IDmeWebVerify.m
+++ b/ID.me WebVerify SDK/IDmeWebVerify.m
@@ -128,11 +128,11 @@
                                         NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
                                         NSUInteger statusCode = [httpResponse statusCode];
                                         if ([data length] && error == nil && statusCode == 200) {
-                                            NSError* error;
-                                            NSDictionary *results = (NSDictionary *)[NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:&error];
-                                            if (error == nil) {
-                                                NSDictionary *userProfile = [self testResultsForNull:results];
-                                                    webVerificationResults(userProfile, nil);
+                                            NSError* serializingError;
+                                            NSMutableDictionary *results = (NSMutableDictionary *)[NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments | NSJSONReadingMutableContainers error:&serializingError];
+                                            [self removeNull:results];
+                                            if (serializingError == nil) {
+                                                    webVerificationResults(results, nil);
                                             } else {
                                                 webVerificationResults(nil, [self failedFetchingProfileErrorWithUserInfo:error.userInfo]);
                                             }
@@ -339,6 +339,14 @@
     return parameters;
 }
 
+- (void)removeNull:(NSMutableDictionary * _Nonnull)results{
+    NSArray *keys = [results allKeys];
+    for (id key in keys) {
+        if ([results valueForKey:key] == [NSNull null]) {
+            [results removeObjectForKey:key];
+        }
+    }
+}
 
 #pragma mark - UIWebViewDelegate Methods
 -(void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation{


### PR DESCRIPTION
Fixes #9 

The user profile response was parsed and all null values were replaced with "Unknown".
Apps should handle null values.

