### PR TITLE
MOB-487: use non-persistent datastore for WKWebView to prevent auto-sign in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ DerivedData
 
 #CocoaPods
 Pods
+
+#Carthage
+Carthage


### PR DESCRIPTION
Fixes [MOB-487: Logout may not be deleting cookies even if they we call the methods to do this.](https://idmeinc.atlassian.net/browse/MOB-487)

## Description
Prevent using persistent cookies/cache in the new WKWebView used in the SDK, but that only work in iOS +9. For iOS 8 we have manually set an invalid value for the cookie header sent. 

Additionally, the SDK was changed to prevent it from touching other app's cookies or cache that weren't created by the SDK.

## Changes proposed in this request:
* Using a non-persistent datastore for WKWebView in iOS +9
* Modified how ID.me cookies were deleted, from now just ID.me cookies are deleted instead the whole cookies set.
* Removed the deletion of cached response present in NSURLCache. SDK doesn’t delete all the NSURLCache’s responses, it specifies in each request the cache policy: 
* Modified the http request's cache policy to `NSURLRequestReloadIgnoringLocalCacheData`

