### PR TITLE
MOB-552: remove DS Logon from supported connection types

### DIFF
--- a/ID.me WebVerify SDK/IDmeWebVerify.h
+++ b/ID.me WebVerify SDK/IDmeWebVerify.h
@@ -46,12 +46,10 @@ typedef NS_ENUM(NSUInteger, IDmeWebVerifyErrorCode)
 /// This enum defines the different connections that a user can connect to. Used to login to the different platforms
 typedef NS_ENUM(NSUInteger, IDmeWebVerifyConnection)
 {
-    IDWebVerifyConnectionDSLogon,
     IDWebVerifyConnectionFacebook,
     IDWebVerifyConnectionGooglePlus,
     IDWebVerifyConnectionLinkedin,
     IDWebVerifyConnectionPaypal
-
 };
 
 /// This enum defines the different IDs that a user can connect to his account.

--- a/ID.me WebVerify SDK/IDmeWebVerify.m
+++ b/ID.me WebVerify SDK/IDmeWebVerify.m
@@ -13,7 +13,7 @@
 #import "ConnectionDelegate.h"
 
 /// API Constants (Production)
-#define IDME_WEB_VERIFY_BASE_URL                        @"https://api.idmelabs.com/"
+#define IDME_WEB_VERIFY_BASE_URL                        @"https://api.id.me/"
 #define IDME_WEB_VERIFY_GET_AUTH_URI                    IDME_WEB_VERIFY_BASE_URL @"oauth/authorize?client_id=%@&redirect_uri=%@&response_type=token&scope=%@"
 #define IDME_WEB_VERIFY_GET_USER_PROFILE                IDME_WEB_VERIFY_BASE_URL @"api/public/v2/data.json?access_token=%@"
 #define IDME_WEB_VERIFY_REGISTER_CONNECTION_URI         IDME_WEB_VERIFY_BASE_URL @"oauth/authorize?client_id=%@&redirect_uri=%@&response_type=code&op=signin&scope=%@&connect=%@&access_token=%@"

--- a/ID.me WebVerify SDK/IDmeWebVerify.m
+++ b/ID.me WebVerify SDK/IDmeWebVerify.m
@@ -13,7 +13,7 @@
 #import "ConnectionDelegate.h"
 
 /// API Constants (Production)
-#define IDME_WEB_VERIFY_BASE_URL                        @"https://api.id.me/"
+#define IDME_WEB_VERIFY_BASE_URL                        @"https://api.idmelabs.com/"
 #define IDME_WEB_VERIFY_GET_AUTH_URI                    IDME_WEB_VERIFY_BASE_URL @"oauth/authorize?client_id=%@&redirect_uri=%@&response_type=token&scope=%@"
 #define IDME_WEB_VERIFY_GET_USER_PROFILE                IDME_WEB_VERIFY_BASE_URL @"api/public/v2/data.json?access_token=%@"
 #define IDME_WEB_VERIFY_REGISTER_CONNECTION_URI         IDME_WEB_VERIFY_BASE_URL @"oauth/authorize?client_id=%@&redirect_uri=%@&response_type=code&op=signin&scope=%@&connect=%@&access_token=%@"
@@ -542,9 +542,6 @@
 #pragma mark - Helpers - Enums
 - (NSString * _Nonnull)stringForConnection:(IDmeWebVerifyConnection)type {
     switch (type) {
-        case IDWebVerifyConnectionDSLogon:
-            return @"dslogon";
-            break;
         case IDWebVerifyConnectionFacebook:
             return @"facebook";
             break;


### PR DESCRIPTION
[MOB-552: Remove DS Logon from the supported connection types in the SDK](https://idmeinc.atlassian.net/browse/MOB-552)

## Description
Removed DS Logon from supported connection types

## Changes proposed in this request:
* Removed item `IDWebVerifyConnectionDSLogon` from enum `IDmeWebVerifyConnection`

## Contains
- [ ] Tests
- [ ] Documentation