### PR TITLE
MOB-439: Access token refreshing

### DIFF
--- a/ID.me WebVerify SDK/IDmeWebVerify.h
+++ b/ID.me WebVerify SDK/IDmeWebVerify.h
@@ -9,6 +9,9 @@
 #import <UIKit/UIKit.h>
 
 #define IDME_WEB_VERIFY_VERIFICATION_WAS_CANCELED    @"The user exited the modal navigationController before being verified."
+#define IDME_WEB_VERIFY_VERIFICATION_FAILED          @"Authorization process failed."
+#define IDME_WEB_VERIFY_REFRESH_TOKEN_FAILED         @"Refreshing the access token failed."
+#define IDME_WEB_VERIFY_REFRESH_TOKEN_EXPIRED        @"The refresh token has expired."
 #define IDME_WEB_VERIFY_ERROR_DOMAIN                 @"ID.me Web Verify Error Domain"
 
 
@@ -38,6 +41,12 @@ typedef NS_ENUM(NSUInteger, IDmeWebVerifyErrorCode)
 
     /// Error thrown when there is no valid token or when a response status code is 401.
     IDmeWebVerifyErrorCodeNotAuthorized,
+
+    /// Error thrown when there is an error refreshing the requested access token
+    IDmeWebVerifyErrorCodeRefreshTokenFailed,
+
+    /// Error thrown when the refresh token has expired
+    IDmeWebVerifyErrorCodeRefreshTokenExpired,
 
     /// Error thrown for not implemented features like token refreshing.
     IDmeWebVerifyErrorCodeNotImplemented
@@ -79,7 +88,7 @@ typedef NS_ENUM(NSUInteger, IDmeWebVerifyLoginType)
  @param clientID The clientID provided by ID.me when registering the app at @b http://developer.id.me
  @param redierectURI The redirectURI provided to ID.me when registering your app at @b http://developer.id.me
  */
-+ (void)initializeWithClientID:(NSString * _Nonnull)clientID redirectURI:(NSString * _Nonnull)redirectURI;
++ (void)initializeWithClientID:(NSString * _Nonnull)clientID clientSecret:(NSString * _Nonnull)clientSecret redirectURI:(NSString * _Nonnull)redirectURI;
 
 /**
  @param externalViewController The viewController which will present the modal navigationController

--- a/ID.me WebVerify SDK/IDmeWebVerify.m
+++ b/ID.me WebVerify SDK/IDmeWebVerify.m
@@ -14,25 +14,35 @@
 
 /// API Constants (Production)
 #define IDME_WEB_VERIFY_BASE_URL                        @"https://api.id.me/"
-#define IDME_WEB_VERIFY_GET_AUTH_URI                    IDME_WEB_VERIFY_BASE_URL @"oauth/authorize?client_id=%@&redirect_uri=%@&response_type=token&scope=%@"
-#define IDME_WEB_VERIFY_SIGN_UP_OR_LOGIN                IDME_WEB_VERIFY_BASE_URL @"oauth/authorize?client_id=%@&redirect_uri=%@&response_type=token&scope=%@&op=%@"
+#define IDME_WEB_VERIFY_GET_AUTH_URI                    IDME_WEB_VERIFY_BASE_URL @"oauth/authorize?client_id=%@&redirect_uri=%@&response_type=code&scope=%@"
+#define IDME_WEB_VERIFY_SIGN_UP_OR_LOGIN                IDME_WEB_VERIFY_BASE_URL @"oauth/authorize?client_id=%@&redirect_uri=%@&response_type=code&scope=%@&op=%@"
+#define IDME_WEB_VERIFY_REFRESH_CODE_URL                IDME_WEB_VERIFY_BASE_URL @"oauth/token"
 #define IDME_WEB_VERIFY_GET_USER_PROFILE                IDME_WEB_VERIFY_BASE_URL @"api/public/v2/data.json?access_token=%@"
 #define IDME_WEB_VERIFY_REGISTER_CONNECTION_URI         IDME_WEB_VERIFY_BASE_URL @"oauth/authorize?client_id=%@&redirect_uri=%@&response_type=code&op=signin&scope=%@&connect=%@&access_token=%@"
 #define IDME_WEB_VERIFY_REGISTER_AFFILIATION_URI        IDME_WEB_VERIFY_BASE_URL @"oauth/authorize?client_id=%@&redirect_uri=%@&response_type=code&scope=%@&access_token=%@"
 
 /// Data Constants
 #define IDME_WEB_VERIFY_ACCESS_TOKEN_PARAM              @"access_token"
+#define IDME_WEB_VERIFY_REFRESH_TOKEN_PARAM             @"refresh_token"
 #define IDME_WEB_VERIFY_EXPIRATION_PARAM                @"expires_in"
+#define IDME_WEB_VERIFY_REFRESH_EXPIRATION_PARAM        @"refresh_expires_in"
 #define IDME_WEB_VERIFY_ERROR_DESCRIPTION_PARAM         @"error_description"
+
+// HTTP methods
+#define GET_METHOD         @"GET"
+#define POST_METHOD        @"POST"
 
 /// Color Constants
 #define kIDmeWebVerifyColorBlue                     [UIColor colorWithRed:48.0f/255.0f green:160.0f/255.0f blue:224.0f/255.0f alpha:1.0f]
 
 @interface IDmeWebVerify () <WKNavigationDelegate, WKUIDelegate>
 
+typedef void (^RequestCompletion)(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error);
+
 @property (nonatomic, copy) IDmeVerifyWebVerifyProfileResults webVerificationProfileResults;
 @property (nonatomic, copy) IDmeVerifyWebVerifyTokenResults webVerificationTokenResults;
 @property (nonatomic, copy) NSString *clientID;
+@property (nonatomic, copy) NSString *clientSecret;
 @property (nonatomic, copy) NSString *redirectURI;
 @property (nonatomic, strong) IDmeWebVerifyKeychainData *keychainData;
 @property (nonatomic, strong) UIViewController *presentingViewController;
@@ -73,9 +83,10 @@
     return self;
 }
 
-+ (void)initializeWithClientID:(NSString * _Nonnull)clientID redirectURI:(NSString * _Nonnull)redirectURI {
++ (void)initializeWithClientID:(NSString * _Nonnull)clientID clientSecret:(NSString * _Nonnull)clientSecret redirectURI:(NSString * _Nonnull)redirectURI {
     NSAssert([IDmeWebVerify sharedInstance].clientID == nil, @"You cannot initialize IDmeWebVerify more than once.");
     [[IDmeWebVerify sharedInstance] setClientID:clientID];
+    [[IDmeWebVerify sharedInstance] setClientSecret:clientSecret];
     [[IDmeWebVerify sharedInstance] setRedirectURI:redirectURI];
 }
 
@@ -259,41 +270,34 @@
     [self.keychainData clean];
 }
 
-- (void)getAccessTokenWithScope:(NSString* _Nullable)scope forceRefreshing:(BOOL)force result:(IDmeVerifyWebVerifyTokenResults _Nonnull)callback{
+- (void)getAccessTokenWithScope:(NSString* _Nullable)scope forceRefreshing:(BOOL)force result:(IDmeVerifyWebVerifyTokenResults _Nonnull)callback {
 
-    if (force) {
-        // TODO: refresh token
-        callback(nil, [self notImplementedErrorWithUserInfo:nil]);
-        return;
-    }
-
-    NSString* token;
-    NSDate* expiration;
-    if (scope) {
-        // get the token for the specified scope
-        token = [self.keychainData accessTokenForScope:scope];
-        expiration = [self.keychainData expirationDateForScope:scope];
-
-    } else {
-        // get last used token
-        NSString* latestScope = [self.keychainData getLatestUsedScope];
+    NSString* latestScope = scope;
+    if (!latestScope) {
+        // get last used scope
+         latestScope = [self.keychainData getLatestUsedScope];
 
         if (!latestScope) {
-            // no token has been requested yet
+            // no token has been requested yet (and no scope provided)
             callback(nil, [self noSuchScopeErrorWithUserInfo:nil]);
             return;
         }
-
-        token = [self.keychainData accessTokenForScope:latestScope];
-        expiration = [self.keychainData expirationDateForScope:latestScope];
     }
+
+    if (force) {
+        [self refreshTokenForScope:latestScope callback:callback];
+        return;
+    }
+
+    NSString* token = [self.keychainData accessTokenForScope:scope];
+    NSDate* expiration = [self.keychainData expirationDateForScope:scope];
 
     if (token) {
         // check if token has expired
         NSDate* now = [[NSDate alloc] init];
         if ([now compare:expiration] != NSOrderedAscending) {
-            // TODO: refresh token
-            callback(nil, [self notAuthorizedErrorWithUserInfo:nil]);
+            // token has expired
+            [self refreshTokenForScope:scope callback:callback];
         } else {
             callback(token, nil);
         }
@@ -302,6 +306,39 @@
         callback(nil, [self noSuchScopeErrorWithUserInfo:nil]);
     }
 
+}
+
+- (void)refreshTokenForScope:(NSString* _Nonnull)scope callback:(IDmeVerifyWebVerifyTokenResults _Nonnull)callback {
+
+    NSString* refreshToken = [self.keychainData refreshTokenForScope:scope];
+    NSDate* expiration = [self.keychainData refreshExpirationDateForScope:scope];
+
+    NSDate* now = [[NSDate alloc] init];
+    if ([now compare:expiration] != NSOrderedAscending) {
+        // refresh token has expired
+        callback(nil, [self refreshTokenExpiredErrorWithUserInfo:@{NSLocalizedDescriptionKey: IDME_WEB_VERIFY_REFRESH_TOKEN_EXPIRED}]);
+    } else {
+        __weak IDmeWebVerify *weakself = self;
+        [self makePostRequestWithUrl:IDME_WEB_VERIFY_REFRESH_CODE_URL
+                          parameters:[NSString stringWithFormat:@"client_id=%@&client_secret=%@&redirect_uri=%@&refresh_token=%@&grant_type=refresh_token",
+                                      _clientID, _clientSecret, _redirectURI, refreshToken]
+                          completion:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+                              NSError *jsonError;
+                              NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data
+                                                                                   options:NSJSONReadingMutableContainers
+                                                                                     error:&jsonError];
+                              if (json && !error) {
+                                  [weakself saveDataFromJson:json];
+                                  NSString * accessToken = [json objectForKey:IDME_WEB_VERIFY_ACCESS_TOKEN_PARAM];
+                                  if (accessToken) {
+                                      callback(accessToken, nil);
+                                      return;
+                                  }
+                              }
+
+                              callback(nil, [weakself refreshTokenErrorWithUserInfo:@{NSLocalizedDescriptionKey: IDME_WEB_VERIFY_REFRESH_TOKEN_FAILED}]);
+                          }];
+    }
 }
 
 #pragma mark - Web view Methods
@@ -521,48 +558,58 @@
          since it allows us to split the return string by components separated by '&'.
          */
         query = [query stringByReplacingOccurrencesOfString:@"#" withString:@"&"];
+        query = [query stringByReplacingOccurrencesOfString:@"?" withString:@"&"];
 
     }
 
     NSDictionary *parameters = [self parseQueryParametersFromURL:query];
 
-    if ([parameters objectForKey:IDME_WEB_VERIFY_ACCESS_TOKEN_PARAM]) {
+    if ([query hasPrefix:_redirectURI]) {
 
-        // Extract 'access_token' from URL query parameters that are separated by '&'
-        NSString *accessToken = [parameters objectForKey:IDME_WEB_VERIFY_ACCESS_TOKEN_PARAM];
-        NSString *expiresIn = [parameters objectForKey:IDME_WEB_VERIFY_EXPIRATION_PARAM];
+        if ([parameters objectForKey:@"code"]) {
 
+            __weak IDmeWebVerify *weakself = self;
+            [self makePostRequestWithUrl:IDME_WEB_VERIFY_REFRESH_CODE_URL
+                              parameters:[NSString stringWithFormat:@"client_id=%@&client_secret=%@&redirect_uri=%@&code=%@&grant_type=authorization_code",
+                                          _clientID, _clientSecret, _redirectURI, [parameters objectForKey:@"code"]]
+                              completion:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+                                  NSError *jsonError;
+                                  NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data
+                                                                                       options:NSJSONReadingMutableContainers
+                                                                                         error:&jsonError];
 
-        //TODO: save refresh token
-        NSDate* expirationDate = [NSDate dateWithTimeIntervalSinceNow:[[NSNumber numberWithInt:[expiresIn intValue]] doubleValue]];
-        [self.keychainData setToken:accessToken expirationDate:expirationDate refreshToken:nil forScope:requestScope];
+                                  if (json) {
+                                      [weakself saveDataFromJson:json];
+                                      if (_loadUser == YES)
+                                          [weakself getUserProfileWithScope:requestScope result:_webVerificationProfileResults];
+                                      else {
+                                          _webVerificationTokenResults([json objectForKey:IDME_WEB_VERIFY_ACCESS_TOKEN_PARAM], nil);
+                                          [weakself destroyWebNavigationController];
+                                      }
+                                  } else {
+                                      _webVerificationTokenResults(nil, [weakself notAuthorizedErrorWithUserInfo:@{NSLocalizedDescriptionKey: IDME_WEB_VERIFY_VERIFICATION_FAILED}]);
+                                  }
+                              }];
+            decisionHandler(WKNavigationActionPolicyCancel);
+            return;
 
-        if (_loadUser == YES)
-            [self getUserProfileWithScope:requestScope result:_webVerificationProfileResults];
-        else {
-            _webVerificationTokenResults(accessToken, nil);
+        } else if ([parameters objectForKey:IDME_WEB_VERIFY_ERROR_DESCRIPTION_PARAM]) {
+
+            // Extract 'error_description' from URL query parameters that are separated by '&'
+            NSString *errorDescription = [parameters objectForKey:IDME_WEB_VERIFY_ERROR_DESCRIPTION_PARAM];
+            errorDescription = [errorDescription stringByReplacingOccurrencesOfString:@"+" withString:@" "];
+            NSDictionary *details = @{ NSLocalizedDescriptionKey : errorDescription };
+            NSError *error = [[NSError alloc] initWithDomain:IDME_WEB_VERIFY_ERROR_DOMAIN code:IDmeWebVerifyErrorCodeVerificationWasDeniedByUser userInfo:details];
+            if (_webVerificationTokenResults) {
+                _webVerificationTokenResults(nil, error);
+            } else {
+                _webVerificationProfileResults(nil, error);
+            }
             [self destroyWebNavigationController];
+
+            decisionHandler(WKNavigationActionPolicyCancel);
+            return;
         }
-
-        decisionHandler(WKNavigationActionPolicyCancel);
-        return;
-
-    } else if ([parameters objectForKey:IDME_WEB_VERIFY_ERROR_DESCRIPTION_PARAM]) {
-
-        // Extract 'error_description' from URL query parameters that are separated by '&'
-        NSString *errorDescription = [parameters objectForKey:IDME_WEB_VERIFY_ERROR_DESCRIPTION_PARAM];
-        errorDescription = [errorDescription stringByReplacingOccurrencesOfString:@"+" withString:@" "];
-        NSDictionary *details = @{ NSLocalizedDescriptionKey : errorDescription };
-        NSError *error = [[NSError alloc] initWithDomain:IDME_WEB_VERIFY_ERROR_DOMAIN code:IDmeWebVerifyErrorCodeVerificationWasDeniedByUser userInfo:details];
-        if (_webVerificationTokenResults) {
-            _webVerificationTokenResults(nil, error);
-        } else {
-            _webVerificationProfileResults(nil, error);
-        }
-        [self destroyWebNavigationController];
-
-        decisionHandler(WKNavigationActionPolicyCancel);
-        return;
     }
 
     decisionHandler(WKNavigationActionPolicyAllow);
@@ -575,6 +622,37 @@
     }
 
     return nil;
+}
+
+#pragma mark - Networking
+- (void)makePostRequestWithUrl:(NSString *_Nonnull)urlString parameters:(NSString* _Nonnull)parameters completion:(RequestCompletion)completion {
+
+    NSData *parameterData = [parameters dataUsingEncoding:NSUTF8StringEncoding];
+    NSURL *url = [NSURL URLWithString:urlString];
+
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+    [request addValue: @"application/x-www-form-urlencoded; charset=utf-8" forHTTPHeaderField:@"Content-Type"];
+    [request setHTTPMethod:POST_METHOD];
+    [request setHTTPBody:parameterData];
+
+    NSURLSession *session = [NSURLSession sharedSession];
+    NSURLSessionDataTask *task = [session dataTaskWithRequest:request
+                                            completionHandler:completion];
+    
+    [task resume];
+}
+
+#pragma mark - Keychain access
+- (void)saveDataFromJson:(NSDictionary* _Nonnull)json {
+    // Extract 'access_token' from URL query parameters that are separated by '&'
+    NSString *accessToken = [json objectForKey:IDME_WEB_VERIFY_ACCESS_TOKEN_PARAM];
+    NSString *refreshToken = [json objectForKey:IDME_WEB_VERIFY_REFRESH_TOKEN_PARAM];
+    NSString *expiresIn = [json objectForKey:IDME_WEB_VERIFY_EXPIRATION_PARAM];
+    NSString *refreshExpiresIn = [json objectForKey:IDME_WEB_VERIFY_REFRESH_EXPIRATION_PARAM];
+
+    NSDate* expirationDate = [NSDate dateWithTimeIntervalSinceNow:[[NSNumber numberWithInt:[expiresIn intValue]] doubleValue]];
+    NSDate* refreshExpirationDate = [NSDate dateWithTimeIntervalSinceNow:[[NSNumber numberWithInt:[refreshExpiresIn intValue]] doubleValue]];
+    [self.keychainData setToken:accessToken expirationDate:expirationDate refreshToken:refreshToken refreshExpDate:refreshExpirationDate forScope:requestScope];
 }
 
 #pragma mark - Accessor Methods
@@ -597,6 +675,14 @@
 
 - (NSError * _Nonnull)notAuthorizedErrorWithUserInfo:(NSDictionary* _Nullable)userInfo {
     return [self errorWithCode:IDmeWebVerifyErrorCodeNotAuthorized userInfo:userInfo];
+}
+
+- (NSError * _Nonnull)refreshTokenErrorWithUserInfo:(NSDictionary* _Nullable)userInfo {
+    return [self errorWithCode:IDmeWebVerifyErrorCodeRefreshTokenFailed userInfo:userInfo];
+}
+
+- (NSError * _Nonnull)refreshTokenExpiredErrorWithUserInfo:(NSDictionary* _Nullable)userInfo {
+    return [self errorWithCode:IDmeWebVerifyErrorCodeRefreshTokenExpired userInfo:userInfo];
 }
 
 - (NSError * _Nonnull)errorWithCode:(IDmeWebVerifyErrorCode)code  userInfo:(NSDictionary* _Nullable)userInfo {

--- a/ID.me WebVerify SDK/IDmeWebVerify.m
+++ b/ID.me WebVerify SDK/IDmeWebVerify.m
@@ -327,7 +327,7 @@ typedef void (^RequestCompletion)(NSData * _Nullable data, NSURLResponse * _Null
                                                                                    options:NSJSONReadingMutableContainers
                                                                                      error:&jsonError];
                               if (json && !error) {
-                                  [weakself saveKeychainDataFromJson:json scope:scope];
+                                  [weakself saveTokenDataFromJson:json scope:scope];
                                   NSString * accessToken = [json objectForKey:IDME_WEB_VERIFY_ACCESS_TOKEN_PARAM];
                                   if (accessToken) {
                                       callback(accessToken, nil);
@@ -578,7 +578,7 @@ typedef void (^RequestCompletion)(NSData * _Nullable data, NSURLResponse * _Null
                                                                                          error:&jsonError];
 
                                   if (json) {
-                                      [weakself saveKeychainDataFromJson:json scope:requestScope];
+                                      [weakself saveTokenDataFromJson:json scope:requestScope];
                                       if (_loadUser == YES)
                                           [weakself getUserProfileWithScope:requestScope result:_webVerificationProfileResults];
                                       else {
@@ -642,7 +642,7 @@ typedef void (^RequestCompletion)(NSData * _Nullable data, NSURLResponse * _Null
 }
 
 #pragma mark - Keychain access
-- (void)saveKeychainDataFromJson:(NSDictionary* _Nonnull)json scope:(NSString* _Nonnull)scope {
+- (void)saveTokenDataFromJson:(NSDictionary* _Nonnull)json scope:(NSString* _Nonnull)scope {
     // Extract 'access_token' from URL query parameters that are separated by '&'
     NSString *accessToken = [json objectForKey:IDME_WEB_VERIFY_ACCESS_TOKEN_PARAM];
     NSString *refreshToken = [json objectForKey:IDME_WEB_VERIFY_REFRESH_TOKEN_PARAM];

--- a/ID.me WebVerify SDK/IDmeWebVerifyKeychainData.h
+++ b/ID.me WebVerify SDK/IDmeWebVerifyKeychainData.h
@@ -16,11 +16,13 @@
 -(NSString* _Nullable)accessTokenForScope:(NSString* _Nonnull)scope;
 -(NSDate* _Nullable)expirationDateForScope:(NSString* _Nonnull)scope;
 -(NSString* _Nullable)refreshTokenForScope:(NSString* _Nonnull)scope;
+-(NSDate * _Nullable)refreshExpirationDateForScope:(NSString * _Nonnull)scope;
 
 // TODO: discuss if refreshToken should be nullable
 -(void)setToken:(NSString * _Nonnull)accessToken
- expirationDate:(NSDate * _Nonnull)date
-   refreshToken:(NSString * _Nullable)refreshToken
+ expirationDate:(NSDate * _Nonnull)expirationDate
+   refreshToken:(NSString * _Nonnull)refreshToken
+ refreshExpDate:(NSDate * _Nonnull)refreshExpDate
        forScope:(NSString * _Nonnull)scope;
 
 -(void)clean;

--- a/ID.me WebVerify SDK/IDmeWebVerifyKeychainData.m
+++ b/ID.me WebVerify SDK/IDmeWebVerifyKeychainData.m
@@ -11,6 +11,7 @@
 /// Keychain Constants
 #define IDME_KEYCHAIN_DATA_ACCOUNT              @"IDME_KEYCHAIN_DATA"
 #define IDME_EXPIRATION_DATE                    @"IDME_EXPIRATION_DATE"
+#define IDME_REFRESH_EXPIRATION_DATE            @"IDME_REFRESH_EXPIRATION_DATE"
 #define IDME_REFRESH_TOKEN                      @"IDME_REFRESH_TOKEN"
 #define IDME_ACCESS_TOKEN                       @"IDME_ACCESS_TOKEN"
 #define IDME_SCOPE                              @"IDME_SCOPE"
@@ -71,17 +72,14 @@
 
 #pragma mark Getters and Setters
 
--(void)setToken:(NSString * _Nonnull)accessToken expirationDate:(NSDate * _Nonnull)date
-   refreshToken:(NSString * _Nullable)refreshToken forScope:(NSString * _Nonnull)scope {
+-(void)setToken:(NSString * _Nonnull)accessToken expirationDate:(NSDate * _Nonnull)expirationDate
+   refreshToken:(NSString * _Nonnull)refreshToken refreshExpDate:(NSDate * _Nonnull)refreshExpDate
+       forScope:(NSString * _Nonnull)scope {
 
-    NSString* refresh = refreshToken;
-    if (!refreshToken && self.tokensByScope[scope]) {
-        refresh = self.tokensByScope[scope][IDME_REFRESH_TOKEN];
-    }
-
-    self.tokensByScope[scope] = @{IDME_EXPIRATION_DATE: [_dateFormatter stringFromDate: date],
-                                  IDME_REFRESH_TOKEN: refresh ?: @"",
-                                  IDME_ACCESS_TOKEN: accessToken};
+    self.tokensByScope[scope] = @{IDME_EXPIRATION_DATE: [_dateFormatter stringFromDate: expirationDate],
+                                  IDME_REFRESH_TOKEN: refreshToken,
+                                  IDME_ACCESS_TOKEN: accessToken,
+                                  IDME_REFRESH_EXPIRATION_DATE: [_dateFormatter stringFromDate: refreshExpDate]};
     self.latestScope = scope;
     [self persist];
 }
@@ -100,6 +98,10 @@
 
 -(NSDate * _Nullable)expirationDateForScope:(NSString * _Nonnull)scope{
     return  [_dateFormatter dateFromString: self.tokensByScope[scope][IDME_EXPIRATION_DATE]];
+}
+
+-(NSDate * _Nullable)refreshExpirationDateForScope:(NSString * _Nonnull)scope{
+    return  [_dateFormatter dateFromString: self.tokensByScope[scope][IDME_REFRESH_EXPIRATION_DATE]];
 }
 
 @end

--- a/Sample Project/WebVerifySample/ViewController.m
+++ b/Sample Project/WebVerifySample/ViewController.m
@@ -15,6 +15,7 @@
 
 @implementation ViewController {
     NSString *clientID;
+    NSString *clientSecret;
     NSString *redirectURL;
     NSString *scope;
 }
@@ -22,12 +23,13 @@
 #pragma mark - View Lifecycle
 - (void)viewDidLoad {
 
-    clientID    = @"<your_client_id>";
+    clientID = @"<your_client_id>";
+    clientSecret = @"<your_client_secret>";
     redirectURL = @"<your_url>";
     scope = @"<your_handle>";
 
     [super viewDidLoad];
-    [IDmeWebVerify initializeWithClientID:clientID redirectURI:redirectURL];
+    [IDmeWebVerify initializeWithClientID:clientID clientSecret: clientSecret redirectURI:redirectURL];
     [self setupSubviews];
 }
 


### PR DESCRIPTION
Fixes #7 

## Description
Access token refreshing implemented using the OAuth flow.
The expiration date of the refresh token is also saved so that if the refresh token is expired then the SDK can return an error immediately

## Todos
- [ ] Tests
- [ ] Documentation
