### PR TITLE
MOB-618: Include mutex when refreshing tokens

### DIFF
--- a/ID.me WebVerify SDK/IDmeWebVerifyKeychainData.m
+++ b/ID.me WebVerify SDK/IDmeWebVerifyKeychainData.m
@@ -38,11 +38,9 @@
 }
 
 -(void)persist{
-    dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
-        NSError* error;
-        NSData *dictionaryRep = [NSPropertyListSerialization dataWithPropertyList:[self tokensByScope] format:NSPropertyListXMLFormat_v1_0 options:0 error:&error];
-        [SAMKeychain setPasswordData:dictionaryRep forService:[NSBundle mainBundle].bundleIdentifier account:IDME_KEYCHAIN_DATA_ACCOUNT error:&error];
-    });
+    NSError* error;
+    NSData *dictionaryRep = [NSPropertyListSerialization dataWithPropertyList:[self tokensByScope] format:NSPropertyListXMLFormat_v1_0 options:0 error:&error];
+    [SAMKeychain setPasswordData:dictionaryRep forService:[NSBundle mainBundle].bundleIdentifier account:IDME_KEYCHAIN_DATA_ACCOUNT error:&error];
 }
 
 -(void)clean {

--- a/ID.me WebVerify SDK/IDmeWebVerifyKeychainData.m
+++ b/ID.me WebVerify SDK/IDmeWebVerifyKeychainData.m
@@ -38,9 +38,11 @@
 }
 
 -(void)persist{
-    NSError* error;
-    NSData *dictionaryRep = [NSPropertyListSerialization dataWithPropertyList:[self tokensByScope] format:NSPropertyListXMLFormat_v1_0 options:0 error:&error];
-    [SAMKeychain setPasswordData:dictionaryRep forService:[NSBundle mainBundle].bundleIdentifier account:IDME_KEYCHAIN_DATA_ACCOUNT error:&error];
+    dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
+        NSError* error;
+        NSData *dictionaryRep = [NSPropertyListSerialization dataWithPropertyList:[self tokensByScope] format:NSPropertyListXMLFormat_v1_0 options:0 error:&error];
+        [SAMKeychain setPasswordData:dictionaryRep forService:[NSBundle mainBundle].bundleIdentifier account:IDME_KEYCHAIN_DATA_ACCOUNT error:&error];
+    });
 }
 
 -(void)clean {


### PR DESCRIPTION
Fixes [MOB-618](https://idmeinc.atlassian.net/browse/MOB-618)

## Description
When refreshing tokens was called twice before the first request returning then the second attempt would fail as the refresh token had already been used.

## Todos
- [ ] Tests
- [ ] Documentation

