### PR TITLE
MOB-665 cancelling request only if we got response from server

### DIFF
--- a/ID.me WebVerify SDK/IDmeConnectionDelegate.m
+++ b/ID.me WebVerify SDK/IDmeConnectionDelegate.m
@@ -25,6 +25,7 @@
     if (query) {
         if ([parameters objectForKey:@"code"] && [query hasPrefix:self.redirectUri]) {
             self.callback(nil, nil);
+            return WKNavigationActionPolicyCancel;
         } else if ([parameters objectForKey:IDME_WEB_VERIFY_ERROR_DESCRIPTION_PARAM] && [parameters objectForKey:IDME_WEB_VERIFY_ERROR_PARAM]) {
             // Extract 'error_description' from URL query parameters that are separated by '&'
             NSString *errorDescription = [parameters objectForKey:IDME_WEB_VERIFY_ERROR_DESCRIPTION_PARAM];
@@ -37,8 +38,8 @@
                 error = [[NSError alloc] initWithDomain:IDME_WEB_VERIFY_ERROR_DOMAIN code:IDmeWebVerifyErrorCodeAuthenticationFailed userInfo:details];
             }
             self.callback(nil, error);
+            return WKNavigationActionPolicyCancel;
         }
-        return WKNavigationActionPolicyCancel;
     }
 
     return WKNavigationActionPolicyAllow;


### PR DESCRIPTION
Fixes [MOB-665 SDK - Add ID and Login returning immediately](https://idmeinc.atlassian.net/browse/MOB-665)

## Description
Previously was canceling the request any time it has some query parameter in the URL. The correct is cancelling the request just when it is the redirect_ur that the SDK expects.