### PR TITLE
[Logout] Add non nullable annotation for UIViewController parameter

### DIFF
--- a/Source/IDmeWebVerify.h
+++ b/Source/IDmeWebVerify.h
@@ -137,7 +137,7 @@ typedef NS_ENUM(NSUInteger, IDmeWebVerifyLoginType)
  @param externalViewController A view controller used to present a web browser which will clear the current session
  @param callback A block that will be called when the session is deleted
  */
-- (void)logoutInViewController:(UIViewController *)externalViewController callback:(IDmeVerifyWebLogoutCallback _Nonnull)callback;
+- (void)logoutInViewController:(UIViewController * _Nonnull)externalViewController callback:(IDmeVerifyWebLogoutCallback _Nonnull)callback;
 
 /**
  Registers a new connection for the user.


### PR DESCRIPTION
## Description
This commit adds the non nullable annotation for the `UIViewController` parameter of the `logout` function. This is needed in order for the compiler to successfully build the framework.

## Changes proposed in this request:
* Added the non nullable annotation for the `UIViewController` parameter of the `logout` function

## Todos
- [x] Tests
- [x] Documentation

